### PR TITLE
fixup configs to work in unscheduled mode, the default in 73X 

### DIFF
--- a/DataFormats/python/EventContent_version9_cff.py
+++ b/DataFormats/python/EventContent_version9_cff.py
@@ -29,7 +29,7 @@ patOutput = cms.OutputModule("PoolOutputModule",
         "keep L1AcceptBunchCrossings_*_*_*",
         "keep L1GlobalTriggerReadoutRecord_gtDigis_*_*",
         
-        'keep recoPFCandidates_*_*_*',
+        'keep recoPFCandidates_particleFlow_*_*',
 
         "keep *_offlineBeamSpot_*_*",
         "keep *_offlinePrimaryVertices_*_*",

--- a/DataFormats/python/RECOtoPAT_cff.py
+++ b/DataFormats/python/RECOtoPAT_cff.py
@@ -5,13 +5,13 @@ from TrackingTools.GeomPropagators.SmartPropagator_cff import *
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import *
 from TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi import *
 
-import PhysicsTools.PatAlgos.patSequences_cff
+from  PhysicsTools.PatAlgos.patSequences_cff import *
 
-muonMatch = PhysicsTools.PatAlgos.patSequences_cff.muonMatch.clone(
+muonMatch = muonMatch.clone(
     src = cms.InputTag("muons"),
     resolveByMatchQuality = cms.bool(True)
 )
-patMuons = PhysicsTools.PatAlgos.patSequences_cff.patMuons.clone(
+patMuons = patMuons.clone(
     muonSource = cms.InputTag("muons"),
     genParticleMatch = cms.InputTag("muonMatch"),
     addTeVRefits = cms.bool(False),
@@ -30,27 +30,27 @@ patMuons = PhysicsTools.PatAlgos.patSequences_cff.patMuons.clone(
     embedTcMETMuonCorrs = cms.bool(False),
 )
 # Tracker Muons Part
-selectedPatTrackerMuons = PhysicsTools.PatAlgos.patSequences_cff.selectedPatMuons.clone(
+selectedPatTrackerMuons = selectedPatMuons.clone(
     src = cms.InputTag("patMuons"),
     cut = cms.string("pt > 5.0 && isTrackerMuon() && numberOfMatches() > 1 && -2.4 < eta() && eta() < 2.4")
 )
-cleanPatTrackerMuons = PhysicsTools.PatAlgos.patSequences_cff.cleanPatMuons.clone(
+cleanPatTrackerMuons = cleanPatMuons.clone(
     src = cms.InputTag("selectedPatTrackerMuons")
 )
-countPatTrackerMuons = PhysicsTools.PatAlgos.patSequences_cff.countPatMuons.clone(
+countPatTrackerMuons = countPatMuons.clone(
     src = cms.InputTag("cleanPatTrackerMuons")
 )
 # PF Muons Part
-selectedPatPFMuons = PhysicsTools.PatAlgos.patSequences_cff.selectedPatMuons.clone(
+selectedPatPFMuons = selectedPatMuons.clone(
     src = cms.InputTag("patMuons"),
     #"Loose Muon" requirement on PF muons as recommended by Muon POG:
     #https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#Loose_Muon
     cut = cms.string("pt > 5.0 && isPFMuon() && ( isTrackerMuon() || isGlobalMuon() ) && -2.4 < eta() && eta() < 2.4")
 )
-cleanPatPFMuons = PhysicsTools.PatAlgos.patSequences_cff.cleanPatMuons.clone(
+cleanPatPFMuons = cleanPatMuons.clone(
     src = cms.InputTag("selectedPatPFMuons")
 )
-countPatPFMuons = PhysicsTools.PatAlgos.patSequences_cff.countPatMuons.clone(
+countPatPFMuons = countPatMuons.clone(
     src = cms.InputTag("cleanPatPFMuons")
 )
 
@@ -142,3 +142,8 @@ patifyMC = cms.Sequence(
     muonMatch * 
     patifyData
 )
+
+patDefaultSequence = cms.Sequence()
+patCandidates = cms.Sequence()
+makePatMuons = cms.Sequence()
+

--- a/DataFormats/scripts/patifyMC_8TeV/PATv3/patTuple_mujets_73X_cfg.py
+++ b/DataFormats/scripts/patifyMC_8TeV/PATv3/patTuple_mujets_73X_cfg.py
@@ -1,0 +1,46 @@
+## import skeleton process
+from PhysicsTools.PatAlgos.patTemplate_cfg import *
+# verbose flags for the PF2PAT modules
+process.options.allowUnscheduled = cms.untracked.bool(True)
+#process.Tracer = cms.Service("Tracer")
+
+#process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+#process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
+
+### Add MuJet Dataformats
+process.load("MuJetAnalysis.DataFormats.RECOtoPAT_cff")
+process.patMuons.addGenMatch = cms.bool(True)
+process.patMuons.embedGenMatch = cms.bool(True)
+
+process.load("MuJetAnalysis.DataFormats.EventContent_version9_cff")
+process.out.fileName = cms.untracked.string("out_pat.root")
+process.out.outputCommands = process.patOutput.outputCommands
+
+
+
+## ------------------------------------------------------
+#  In addition you usually want to change the following
+#  parameters:
+## ------------------------------------------------------
+#
+#   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
+#                                         ##
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(
+    "file:/eos/uscms/store/user/lpcgem/dildick/CMSSW_73/dildick/DarkSUSY_mH_125_mGammaD_0400_ctauExp_2_8TeV_madgraph452_bridge224_LHE_pythia6_RAW/DarkSUSY_mH_125_mGammaD_0400_ctauExp_2_8TeV_madgraph452_bridge224_LHE_pythia6_RECO/ee2b69195f87ad6497ae607e47718adf/out_reco_1_1_XNE.root"
+#      "file:CrabJobs/out_reco.root"
+  )
+)
+
+#                                         ##
+process.maxEvents.input = 100
+#                                         ##
+#   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
+#                                         ##
+#process.out.fileName = 'patTuple_PF2PAT.root'
+#                                         ##
+#   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)
+
+#prints modules as they are called with times
+#from Validation.Performance.TimeMemoryInfo import customise
+#process = customise(process)


### PR DESCRIPTION
 DataFormats/scripts/patifyMC_8TeV/PATv3/patTuple_mujets_73X_cfg.py 

(somewhat hacky in a few places)
the starting point should have been patTuple_standard_cfg.py, not the PF2PAT,
after that it was important to load all module configurations to make missing products;
and then also fix the keep statements to not have wildcards for things that are loaded in configs and would've been created on the fly (unintentionally).

From looking at the sequence of modules called by the unscheduled framework, it seems like the "on the fly" objects are only the isolations, as expected; nothing surprising was dragged in.